### PR TITLE
Add single VM from multi-VM vapp migration path

### DIFF
--- a/vcd_to_vcenter.ps1
+++ b/vcd_to_vcenter.ps1
@@ -1,13 +1,15 @@
 # vcd_to_vcenter.ps1 - Downloads and converts a VM from vCloud Director to vCenter
 
 # USER VARIABLES
-# Set the name of the VM we want to download, the destination VMhost and the destination datastore
-$vm_name = "my_vm"
-$dest_dc = "my_datacenter"
-$dest_cluster = "my_cluster"
-$dest_datastore = "my_datastore"
-$dest_network = "my_dvs_portgroup"
-$poweron_vm_at_destination = $false
+$vm_name = "pmailrelayanma1" # VM we ultimately want to convert
+$dns_suffix = "services.brown.edu" # DNS suffix for the VM. Used if running a script on the VM prior to conversion
+$vapp_name = "pmailrelayanma1" # vApp name. Will usually equal $vm_name, but not always. See instruction doc
+$dest_dc = "PRD" # Destination datastore in vCenter
+$dest_cluster = "prd500-cluster" # Destination cluster in vCenter
+$dest_datastore = "ds-p5-sc5020-lun002b" # Destination datastore in vCenter
+$dest_network = "vcd_migration" # Destination network in vCenter.
+$vm_command = "" # Command to run on the VM prior to migration, if desired
+$poweron_vm_at_destination = $false # If $true, the VM will be powered on after migration is complete
 
 # Set some execution environment variables - I use LastPass and set these environment variables prior to execution. Don't save them in a script file.
 $vcd_server = $Env:VCD_SERVER
@@ -21,17 +23,48 @@ $vsphere_password = $Env:VSPHERE_PASSWORD
 
 # Don't touch the stuff below unless you know what you're doing
 
+$vcd_vdc = "Production"
+# If we use a temporary vApp for migration, this will be set to true
+$temporary_vapp_in_use = $false
+
 # Create VCD and vCenter instances
 
-$vcd_instance = Connect-CIServer -Server $vcd_server -Org $vcd_org -User $vcd_username -Password $vcd_password
-$vsphere_instance = Connect-VIServer -Server $vsphere_server -User $vsphere_username -Password $vsphere_password
+Connect-CIServer -Server $vcd_server -Org $vcd_org -User $vcd_username -Password $vcd_password
+Connect-VIServer -Server $vsphere_server -User $vsphere_username -Password $vsphere_password
 
+# Load the VM and vApp PS objects with data
 $source_vm = Get-CIVM -Name $vm_name
-$source_vapp = Get-CIVapp -Name $vm_name
+$source_vapp = Get-CIVapp -Name $vapp_name
+
+# Make sure the user actually wants to continue when a vApp contains multiple VMs
+If (($source_vapp | Get-CIVM | Measure-Object).Count -gt 1) {
+    Write-Output "The vApp contains more than one VM. Assuming you want only one VM. vCloud Director CLI must be installed to continue."
+    ((Get-Command "vcd" -ErrorAction SilentlyContinue) -eq $null) {
+        Write-Output "Command vcd not found. Migration will not continue."
+        exit
+    }
+    Write-Output "Dropping into vcd-cli to complete VM copy"
+    vcd login $vcd_server $vcd_org $vcd_username --password $vcd_password --vdc ${vcd_vdc} -w -i
+    vcd vapp create ${vapp_name}_vc_migration
+    vcd vm shutdown ${vapp_name} ${vm_name}
+    vcd vm copy --target-vapp-name ${vapp_name}_vc_migration --target-vm-name ${vm_name} ${vapp_name} ${vm_name}
+    $source_vapp = Get-CIVM -Name ${vapp_name}_vc_migration
+    $temporary_vapp_in_use = $true
+}
+
+# Run a user-provided command on the VM prior to migration
+If ($vm_command -ne "") {
+    Write-Output "User requested to run a command on the remote VM prior to shutdown"
+    ssh ${vm_local_username}@${vm_name}.${dns_suffix} ${vm_command}
+}
+
+# Set the migrated VM's name
 $dest_vm_name = "${vm_name}-vcd-migrated"
 
-# Shutdown the source VM and vApp and spin until they are shut off
+# Have to have the source's network name, so grab it
+$source_network = ($source_vm | Get-CINetworkAdapter).ExtensionData.Network
 
+# Shutdown the source VM and vApp and spin until they are shut off
 $source_vapp | Stop-CIVappGuest -Confirm:$false
 
 # Poll for VM to be shut down
@@ -41,21 +74,28 @@ while ((Get-CIVM $source_vm).Status -eq "PoweredOn") {
 }
 
 # Make sure the vApp is in a stopped state
-$source_vapp | Stop-CIVapp
+$source_vapp | Stop-CIVapp -Confirm:$false
 
 # Download and Import the VM to vCenter
-
 Write-Output "Starting download of OVF from vCloud. This will take a while. Grab a beverage."
-ovftool --datastore=${dest_datastore} --network=${dest_network} "vcloud://${vcd_username}:${vcd_password}@${vcd_server}/cloud?org=${vcd_org}&vdc=Production&catalog=Brown%20Catalog&vapp=${vm_name}" "vi://${vsphere_username}:${vsphere_password}@${vsphere_server}/${dest_dc}/host/${dest_cluster}/Resources/${dest_vm_name}"
+$start_time = (Get-Date).Second
+ovftool --datastore=${dest_datastore} --net:"${source_network}=${dest_network}" --name=${dest_vm_name} "vcloud://${vcd_username}:${vcd_password}@${vcd_server}/cloud?org=${vcd_org}&vdc=Production&catalog=Brown%20Catalog&vapp=${vapp_name}" "vi://${vsphere_username}:${vsphere_password}@${vsphere_server}/${dest_dc}/host/${dest_cluster}/Resources"
+$end_time = (Get-Date).Second
+
+Write-Output "Download took $($end_time - $start_time) seconds to run."
 
 # Get the VM information from vCenter and disconnect the network
-
 $dest_vm = Get-VM $dest_vm_name
-
 $dest_vm | Get-NetworkAdapter | Set-NetworkAdapter -Connected $false
 
 # If variable is set, power on the VM at the destination vCenter
-
 If ($poweron_vm_at_destination) {
     $dest_vm | Start-VM
+}
+
+If ($temporary_vapp_in_use) {
+    $confirmation = Read-Host "Delete temporary vCloud vApp? (y/n)"
+    if ($confirmation -eq 'y') {
+        vcd vapp delete -y ${source_vapp}.Name
+    }
 }

--- a/vcd_to_vcenter_instructions.md
+++ b/vcd_to_vcenter_instructions.md
@@ -11,6 +11,7 @@ This script assists in the migration of VMs from vCloud Director instances to vC
 
 * LastPass
 * ssh (for remote script execution)
+* vcd-cli (for handling multiple VM vApps. Instructions: http://vmware.github.io/vcd-cli/
 
 ### Getting Started
 
@@ -64,6 +65,12 @@ $vm_command = "hostname" # Command to run on the VM prior to migration, if desir
 
 With the above variables filled out in the script, execute the script with `./vcd_to_vcenter.ps1` or `pwsh vcd_to_vcenter.ps1` if not in a current PS session. The script will probably take a while and advise you to get a drink because the migration involves two steps, a conversion to OVF and a download step. The speed of these tasks is entirely dependent on the size of the VM.
 
+### Handling multiple VM vApps
+
+Newly added is a feature that allows the script to handle vApps with multiple VMs while maintaining uptime for the rest of the VMs in the vApp. This is accomplished using the vcd-cli python package. Install instructions are here: http://vmware.github.io/vcd-cli/. If this package is installed, the script will automatically shutdown the target VM, create a new vApp, and copy the VM into it. The migration will then continue using the temporary vApp.
+
+When migration is complete, you will be prompted to remove the temporary vApp. It is generally safe and recommended to do so.
+
 ### Known Issues
 
-A vApp can contain multiple VMs. The script does have a safety switch to catch if a VM in part of a vApp with more than one VM so unintended VM shutdown does not occur. Moving a vApp with multiple VMs is possible, but may take an extremely long time and increases the chance of transfer failure (of which there is no recovery). To increase the chances of success, it is recommended that you create a temporary vApp and copy your VM into it. This can be accomplished using the vCloud Director interface. Complete instructions for this are beyond the scope of this document. Email `cis-vo@brown.edu` for support.
+A vApp can contain multiple VMs. The script does have a safety switch to catch if a VM in part of a vApp with more than one VM so unintended VM shutdown does not occur. Moving a vApp with multiple VMs is possible, but may take an extremely long time and increases the chance of transfer failure (of which there is no recovery). To increase the chances of success, it is recommended that you create a temporary vApp and copy your VM into it.


### PR DESCRIPTION
Newly added is a feature that allows the script to handle vApps with multiple VMs while maintaining uptime for the rest of the VMs in the vApp. This is accomplished using the vcd-cli python package. Install instructions are here: http://vmware.github.io/vcd-cli/. If this package is installed, the script will automatically shutdown the target VM, create a new vApp, and copy the VM into it. The migration will then continue using the temporary vApp.